### PR TITLE
Fix name when name != title

### DIFF
--- a/lib/puppet/provider/service/pacemaker.rb
+++ b/lib/puppet/provider/service/pacemaker.rb
@@ -26,6 +26,12 @@ Puppet::Type.type(:service).provide(:pacemaker, :parent => Puppet::Provider::Pac
       @name = primitive_name
       return @name
     end
+    primitive_name = resource[:name]
+    if primitive_exists? primitive_name
+      debug "Primitive with name '#{primitive_name}' was found in CIB"
+      @name = primitive_name
+      return @name
+    end
     primitive_name = "p_#{title}"
     if primitive_exists? primitive_name
       debug "Using '#{primitive_name}' name instead of '#{title}'"


### PR DESCRIPTION
When name != title, service provider is not able to find a proper resource
in CIB. This patch fixes the behaviour caused by
fe2789477439f54a8adecf87483e537417e943c8

Change-Id: I19570a40a585db6d27f955deeff48bc4a0dedc7e
Signed-off-by: Sergii Golovatiuk <sgolovatiuk@mirantis.com>